### PR TITLE
use errors.Is

### DIFF
--- a/har.go
+++ b/har.go
@@ -648,7 +648,7 @@ func postData(req *http.Request, withBody bool) (*PostData, error) {
 		var mpr = multipart.NewReader(br, ps["boundary"])
 		for {
 			p, err := mpr.NextPart()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {


### PR DESCRIPTION
`mpr.NextPart()` returns an wrapped `io.EOF`, so `err == io.EOF` doesn't always catch it.

This change switches to the more modern `errors.Is` to detect that case.